### PR TITLE
Bug 1238366 - Dynamically discover the app group name

### DIFF
--- a/AppInfo.swift
+++ b/AppInfo.swift
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+public class AppInfo {
+    /// Return the shared container identifier (also known as the app group) to be used with for example background
+    /// http requests. It is the base bundle identifier with a "group." prefix.
+    public static func sharedContainerIdentifier() -> String? {
+        if let baseBundleIdentifier = AppInfo.baseBundleIdentifier() {
+            return "group." + baseBundleIdentifier
+        }
+        return nil
+    }
+
+    /// Return the base bundle identifier.
+    ///
+    /// This function is smart enough to find out if it is being called from an extension or the main application. In
+    /// case of the former, it will chop off the extension identifier from the bundle since that is a suffix not part
+    /// of the *base* bundle identifier.
+    public static func baseBundleIdentifier() -> String? {
+        let bundle = NSBundle.mainBundle()
+        if let packageType = bundle.objectForInfoDictionaryKey("CFBundlePackageType") as? NSString {
+            if let baseBundleIdentifier = bundle.bundleIdentifier {
+                if packageType == "XPC!" {
+                    let components = baseBundleIdentifier.componentsSeparatedByString(".")
+                    return components[0..<components.count-1].joinWithSeparator(".")
+                }
+                return baseBundleIdentifier
+            }
+        }
+        return nil
+    }
+
+    /// Return the bundle identifier of the content blocker extension. We can't simply look it up from the
+    /// NSBundle because this code can be called from both the main app and the extension.
+    public static func contentBlockerBundleIdentifier() -> String? {
+        guard let baseBundleIdentifier = baseBundleIdentifier() else {
+            return nil
+        }
+        return baseBundleIdentifier + ".ContentBlocker"
+    }
+}

--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -38,6 +38,8 @@
 		D3BFCB5B1BD15CD000AD22D1 /* rights.html in Resources */ = {isa = PBXBuildFile; fileRef = D3BFCB5A1BD15CD000AD22D1 /* rights.html */; };
 		D3C0EEF11BE97D9300BD89C1 /* TitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C0EEF01BE97D9300BD89C1 /* TitleView.swift */; };
 		D3C0EEFD1BE97F9300BD89C1 /* blocker-enabled-detector.json in Resources */ = {isa = PBXBuildFile; fileRef = D3C0EEFC1BE97F9300BD89C1 /* blocker-enabled-detector.json */; };
+		E43A10781C42BBE400FE695B /* AppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43A10771C42BBE400FE695B /* AppInfo.swift */; };
+		E43A10791C42BBE400FE695B /* AppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43A10771C42BBE400FE695B /* AppInfo.swift */; };
 		E4BF2DD71BACE8CA00DA9D68 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4BF2DD61BACE8CA00DA9D68 /* AppDelegate.swift */; };
 		E4BF2DDE1BACE8CA00DA9D68 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E4BF2DDD1BACE8CA00DA9D68 /* Assets.xcassets */; };
 		E4BF2DF11BACE92400DA9D68 /* ActionRequestHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4BF2DF01BACE92400DA9D68 /* ActionRequestHandler.swift */; };
@@ -209,6 +211,7 @@
 		D3BFCB5A1BD15CD000AD22D1 /* rights.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = rights.html; sourceTree = "<group>"; };
 		D3C0EEF01BE97D9300BD89C1 /* TitleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TitleView.swift; sourceTree = "<group>"; };
 		D3C0EEFC1BE97F9300BD89C1 /* blocker-enabled-detector.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "blocker-enabled-detector.json"; path = "Lists/blocker-enabled-detector.json"; sourceTree = SOURCE_ROOT; };
+		E43A10771C42BBE400FE695B /* AppInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppInfo.swift; sourceTree = "<group>"; };
 		E4BF2DD31BACE8CA00DA9D68 /* Focus.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Focus.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E4BF2DD61BACE8CA00DA9D68 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E4BF2DDD1BACE8CA00DA9D68 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -275,6 +278,7 @@
 			isa = PBXGroup;
 			children = (
 				E4BF2E101BAD8AC500DA9D68 /* Settings.swift */,
+				E43A10771C42BBE400FE695B /* AppInfo.swift */,
 			);
 			name = Shared;
 			sourceTree = "<group>";
@@ -616,6 +620,7 @@
 				D3BFCB511BD1559300AD22D1 /* AboutContentViewController.swift in Sources */,
 				D37DE54D1BCDB86100906364 /* IntroSlideFinish.swift in Sources */,
 				D3C0EEF11BE97D9300BD89C1 /* TitleView.swift in Sources */,
+				E43A10781C42BBE400FE695B /* AppInfo.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -625,6 +630,7 @@
 			files = (
 				E4BF2E121BAD8AC500DA9D68 /* Settings.swift in Sources */,
 				E4BF2DF11BACE92400DA9D68 /* ActionRequestHandler.swift in Sources */,
+				E43A10791C42BBE400FE695B /* AppInfo.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -5,8 +5,6 @@
 import SafariServices
 import UIKit
 
-private let ContentBlockerBundleIdentifier = "org.mozilla.ios.Focus.ContentBlocker"
-
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate, MainViewControllerDelegate, IntroViewControllerDelegate {
     var window: UIWindow?
@@ -73,10 +71,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate, MainViewControllerDelegat
     }
 
     private func reloadContentBlocker() {
-        SFContentBlockerManager.reloadContentBlockerWithIdentifier(ContentBlockerBundleIdentifier, completionHandler: { (error) -> Void in
-            if let error = error {
-                NSLog("Failed to reload \(ContentBlockerBundleIdentifier): \(error.description)")
-            }
-        })
+        if let identifier = AppInfo.contentBlockerBundleIdentifier() {
+            SFContentBlockerManager.reloadContentBlockerWithIdentifier(identifier, completionHandler: {
+                (error) -> Void in
+                if let error = error {
+                    NSLog("Failed to reload \(identifier): \(error.description)")
+                }
+            })
+        }
     }
 }

--- a/Shared/Settings.swift
+++ b/Shared/Settings.swift
@@ -5,8 +5,6 @@
 import Foundation
 
 struct Settings {
-    static let SuiteName = "group.org.mozilla.ios.Focus"
-
     static let KeyBlockAds = "BlockAds"
     static let KeyBlockAnalytics = "BlockAnalytics"
     static let KeyBlockSocial = "BlockSocial"
@@ -23,13 +21,18 @@ struct Settings {
     }
 
     static func getBool(name: String) -> Bool? {
-        return NSUserDefaults(suiteName: SuiteName)?.objectForKey(name) as? Bool
+        guard let suiteName = AppInfo.sharedContainerIdentifier() else {
+            return nil
+        }
+        return NSUserDefaults(suiteName: suiteName)?.objectForKey(name) as? Bool
     }
 
     static func set(value: Bool, forKey key: String) {
-        if let defaults = NSUserDefaults(suiteName: SuiteName) {
-            defaults.setBool(value, forKey: key)
-            defaults.synchronize()
+        if let suiteName = AppInfo.sharedContainerIdentifier() {
+            if let defaults = NSUserDefaults(suiteName: suiteName) {
+                defaults.setBool(value, forKey: key)
+                defaults.synchronize()
+            }
         }
     }
 }


### PR DESCRIPTION
This patch removed hardcoded references to `org.mozilla.ios.Focus` and replaces it with calls to the same `AppInfo` utility class that we use in Firefox for iOS.