### PR TITLE
Bug 1238410 - Support word wrapping in cell labels

### DIFF
--- a/Blockzilla/MainViewController.swift
+++ b/Blockzilla/MainViewController.swift
@@ -36,6 +36,13 @@ class MainViewController: UIViewController, UITableViewDataSource, UITableViewDe
         BlockerToggle(label: LabelBlockFonts, key: Settings.KeyBlockFonts),
     ]
 
+    /// Used to calculate cell heights.
+    private lazy var dummyToggleCell: UITableViewCell = {
+        let cell = UITableViewCell(style: .Subtitle, reuseIdentifier: "dummyCell")
+        cell.accessoryView = UISwitch()
+        return cell
+    }()
+
     override func viewDidLoad() {
         view.backgroundColor = UIConstants.Colors.Background
 
@@ -165,7 +172,27 @@ class MainViewController: UIViewController, UITableViewDataSource, UITableViewDe
             return heightForCustomCellWithView(headerView)
         }
 
-        return tableView.rowHeight
+        // We have to manually calculate the cell height since UITableViewCell don't correctly
+        // layout multiline detailTextLabels.
+        let toggle = toggleForIndexPath(indexPath)
+        let tableWidth = tableView.frame.width
+        let accessoryWidth = dummyToggleCell.accessoryView!.frame.width
+        let insetsWidth = 2 * tableView.separatorInset.left
+        let width = tableWidth - accessoryWidth - insetsWidth
+
+        var height = heightForLabel(dummyToggleCell.textLabel!, width: width, text: toggle.label)
+        if let subtitle = toggle.subtitle {
+            height += heightForLabel(dummyToggleCell.detailTextLabel!, width: width, text: subtitle)
+        }
+
+        return height + 22
+    }
+
+    private func heightForLabel(label: UILabel, width: CGFloat, text: String) -> CGFloat {
+        let size = CGSizeMake(width, CGFloat.max)
+        let attrs = [NSFontAttributeName: label.font]
+        let boundingRect = NSString(string: text).boundingRectWithSize(size, options: NSStringDrawingOptions.UsesLineFragmentOrigin, attributes: attrs, context: nil)
+        return boundingRect.height
     }
 
     func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {

--- a/Blockzilla/MainViewController.swift
+++ b/Blockzilla/MainViewController.swift
@@ -106,6 +106,14 @@ class MainViewController: UIViewController, UITableViewDataSource, UITableViewDe
         return UIStatusBarStyle.LightContent
     }
 
+    private func toggleForIndexPath(indexPath: NSIndexPath) -> BlockerToggle {
+        var index = indexPath.row
+        for i in 1..<indexPath.section {
+            index += tableView.numberOfRowsInSection(i)
+        }
+        return toggles[index]
+    }
+
     func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         let cell = UITableViewCell(style: .Subtitle, reuseIdentifier: "toggleCell")
         switch indexPath.section {
@@ -114,15 +122,14 @@ class MainViewController: UIViewController, UITableViewDataSource, UITableViewDe
             headerView.snp_makeConstraints { make in
                 make.edges.equalTo(cell)
             }
-        case 1:
-            let toggle = toggles[indexPath.row]
+        case 1: fallthrough
+        case 2:
+            let toggle = toggleForIndexPath(indexPath)
             cell.textLabel?.text = toggle.label
+            cell.textLabel?.numberOfLines = 0
             cell.accessoryView = toggle.toggle
             cell.detailTextLabel?.text = toggle.subtitle
-        case 2:
-            let toggle = toggles[indexPath.row + 4]
-            cell.textLabel?.text = toggle.label
-            cell.accessoryView = toggle.toggle
+            cell.detailTextLabel?.numberOfLines = 0
         default:
             break
         }
@@ -154,14 +161,11 @@ class MainViewController: UIViewController, UITableViewDataSource, UITableViewDe
     }
 
     func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
-        switch indexPath.section {
-        case 0:
+        if indexPath.section == 0 {
             return heightForCustomCellWithView(headerView)
-        default:
-            break
         }
 
-        return 44
+        return tableView.rowHeight
     }
 
     func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
@@ -291,11 +295,11 @@ class MainViewController: UIViewController, UITableViewDataSource, UITableViewDe
 
 
 private class TableFooterView: UIView {
-    var logo: UIImageView = {
+    lazy var logo: UIImageView = {
         var image =  UIImageView(image: UIImage(named: "FooterLogo"))
         image.contentMode = UIViewContentMode.Center
         return image
-        }()
+    }()
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Blockzilla/MainViewController.swift
+++ b/Blockzilla/MainViewController.swift
@@ -39,7 +39,7 @@ class MainViewController: UIViewController, UITableViewDataSource, UITableViewDe
     /// Used to calculate cell heights.
     private lazy var dummyToggleCell: UITableViewCell = {
         let cell = UITableViewCell(style: .Subtitle, reuseIdentifier: "dummyCell")
-        cell.accessoryView = UISwitch()
+        cell.accessoryView = PaddedSwitch(switchView: UISwitch())
         return cell
     }()
 
@@ -134,7 +134,7 @@ class MainViewController: UIViewController, UITableViewDataSource, UITableViewDe
             let toggle = toggleForIndexPath(indexPath)
             cell.textLabel?.text = toggle.label
             cell.textLabel?.numberOfLines = 0
-            cell.accessoryView = toggle.toggle
+            cell.accessoryView = PaddedSwitch(switchView: toggle.toggle)
             cell.detailTextLabel?.text = toggle.subtitle
             cell.detailTextLabel?.numberOfLines = 0
         default:
@@ -320,6 +320,22 @@ class MainViewController: UIViewController, UITableViewDataSource, UITableViewDe
     }
 }
 
+private class PaddedSwitch: UIView {
+    private static let Padding: CGFloat = 8
+
+    init(switchView: UISwitch) {
+        super.init(frame: CGRectZero)
+
+        addSubview(switchView)
+
+        frame.size = CGSizeMake(switchView.frame.width + PaddedSwitch.Padding, switchView.frame.height)
+        switchView.frame.offsetInPlace(dx: PaddedSwitch.Padding, dy: 0)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
 
 private class TableFooterView: UIView {
     lazy var logo: UIImageView = {


### PR DESCRIPTION
This one took me many hours to figure out. For some reason, `UITableView` can't properly calculate the height of cells that have multiline detail text labels. We can specify the height manually in `heightForRowAtIndexPath`, but to calculate the height, we have to measure the labels in the cell. That requires knowing the max width of these labels, which we can hackily determine by subtracting the cell insets and the accessory view width from the entire table view's width, assuming the text labels will fill the remainder.