### PR TITLE
Specify the preferred status bar style in Info.plist

### DIFF
--- a/Blockzilla/Info.plist
+++ b/Blockzilla/Info.plist
@@ -30,6 +30,8 @@
 	<array>
 		<string>arm64</string>
 	</array>
+	<key>UIStatusBarStyle</key>
+	<string>UIStatusBarStyleLightContent</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
This allows the status bar to be displayed correctly in the Launch Screen.

![bar](https://cloud.githubusercontent.com/assets/28428/12498976/8b9c26d6-c074-11e5-949c-21e8f64d4745.png)

